### PR TITLE
Fix the tl;dr in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![screen register](https://github.com/warehouseman/meteor-mantra-kickstarter/blob/trunk/public/screens/users.collection.png)
 
-### tl, dr!
+### TL;DR
 
 This is a starter app for Meteor developers who want to structure their work according to the [Mantra Specification](https://kadirahq.github.io/mantra/).
 


### PR DESCRIPTION
Pedantic bit twiddling:

1) tl;dr is usually separated by a semicolon, not a comma, as this (semi ironically) is more grammatically correct. 
2) No space between the clauses.
3) No need for the exclamation mark - people who know this meme know it's a joke. (And those who don't can now search with a better chance of finding it).
4) Lower case looks wrong for a title, so making it upper case which is an accepted variation.

tl;dr: I fixed your tl;dr. :laughing: